### PR TITLE
Upgrade to SBT 1.0.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ name := "food-hygiene"
 
 version := "1.0"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.4"
 
-val http4sVersion = "0.17.0-M1"
-val circeVersion = "0.7.1"
+val http4sVersion = "0.17.6"
+val circeVersion = "0.8.0"
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-dsl" % http4sVersion,
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   // Test
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.mockito" % "mockito-core" % "2.7.21" % "test",
-  "com.github.tomakehurst" % "wiremock" % "2.6.0" % "test"
+  "com.github.tomakehurst" % "wiremock" % "2.12.0" % "test"
 )
 
 // Packaging

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,17 +1,17 @@
 // Packing plugin (provides universal:packaging)
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 
 // Code coverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 // Scala Style
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 // Templates
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
 
 // Triggered re-start
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 // Dependency tree
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/src/main/scala/hygiene/Server.scala
+++ b/src/main/scala/hygiene/Server.scala
@@ -1,7 +1,5 @@
 package hygiene
 
-import java.util.concurrent.Executors
-
 import hygiene.client.JsonClient
 import hygiene.middleware.CachingMiddleware
 import hygiene.routes.AuthorityController
@@ -24,10 +22,10 @@ object Server extends StreamApp {
 
   val authController = new AuthorityController(establishmentService, authorityService)
 
-  override def main(args: List[String]) = {
+  override def stream(args: List[String]) = {
     // Unconfigured, will bind to 8080
     BlazeBuilder.bindHttp()
-      .withServiceExecutor(Executors.newCachedThreadPool())
+      .withExecutionContext(scala.concurrent.ExecutionContext.global)
       .mountService(CachingMiddleware.cacheRoot(authController.endpoints), "/")
       .serve
   }

--- a/src/main/scala/hygiene/routes/AuthorityController.scala
+++ b/src/main/scala/hygiene/routes/AuthorityController.scala
@@ -12,7 +12,6 @@ class AuthorityController(establishmentService: HygieneRatings, authorityService
   val endpoints: HttpService = HttpService {
 
     case GET -> Root => {
-
       authorityService
         .authorities
         .map(toIndexHtml)

--- a/src/test/scala/hygiene/client/JsonClientTest.scala
+++ b/src/test/scala/hygiene/client/JsonClientTest.scala
@@ -3,6 +3,7 @@ package hygiene.client
 import com.github.tomakehurst.wiremock._
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
+
 import fs2.Task
 import io.circe.Json
 import org.http4s.client.blaze.PooledHttp1Client

--- a/src/test/scala/hygiene/client/JsonClientTest.scala
+++ b/src/test/scala/hygiene/client/JsonClientTest.scala
@@ -3,7 +3,6 @@ package hygiene.client
 import com.github.tomakehurst.wiremock._
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-
 import fs2.Task
 import io.circe.Json
 import org.http4s.client.blaze.PooledHttp1Client


### PR DESCRIPTION
Upgraded SBT from 0.13.x to 1.0.3
Upgraded http4s from milestone release to latest 0.17.x release
Upgraded circe to 0.8.x
Upgraded twirl to enable SBT 1.0.x support.